### PR TITLE
Fix delete repository

### DIFF
--- a/core/core.php
+++ b/core/core.php
@@ -193,7 +193,7 @@
 	 $url .= $_SERVER["REQUEST_URI"];
 	 return $url;
 	}
-	function rrmdir($rrmdir) { 
+	function rrmdir($dir) { 
 		# delete a folder and its content
 	   if (is_dir($dir)) { 
 	     $objects = scandir($dir); 


### PR DESCRIPTION
Before, deleting a directory did nothing since the variable name was not in use. Now the variable is the parameter.