### PR TITLE
for upload file size take the local_value from php ini

### DIFF
--- a/core/auto_dropzone.php
+++ b/core/auto_dropzone.php
@@ -74,10 +74,10 @@ if (!is_array($auto_dropzone['destination_filepath'])&&!is_dir($_SESSION['upload
 }   
 
 // Handle the unit (M/G) in max post/upload size
-$ini_max_upload=$phpini['upload_max_filesize']['global_value'];
+$ini_max_upload=$phpini['upload_max_filesize']['local_value'];
 if (strpos($ini_max_upload,'G')!=false){$ini_max_upload=intval($ini_max_upload*1024);}
 else{$ini_max_upload=intval($ini_max_upload);}
-$ini_max_post=$phpini['post_max_size']['global_value'];
+$ini_max_post=$phpini['post_max_size']['local_value'];
 if (strpos($ini_max_post,'G')!=false){$ini_max_post=intval($ini_max_post*1024);}
 else{$ini_max_post=intval($ini_max_post);}
 


### PR DESCRIPTION
This PR ensure that we use the local_value of php ini values.
It allows to override the max_file_size only for the BoZoN site and not for all other site of the server.

Hope you will find it useful.