### PR TITLE
log login authentication error in webserver log

### DIFF
--- a/core/auto_restrict.php
+++ b/core/auto_restrict.php
@@ -188,7 +188,8 @@
 	if (isset($_POST['login'])&&isset($_POST['pass'])&&empty($_POST['confirm'])&&empty($_POST['creation'])){
 		$ok=log_user($_POST['login'],$_POST['pass']);
 		if (!$ok){
-			
+			// log login failure in web server log to allow fail2ban usage
+			error_log('BoZon: user '.$_POST['login'].' authentication failure');
 			if (!checkIP()){death('Too mutch errors logging in ! You are bannished !');}
 			else{add_banned_ip();safe_redirect('index.php?p=login&error=2');}
 		}


### PR DESCRIPTION
This PR ensure that everytime a login failure occurs an error message is sent to the web server error log.
It allows using tools like fail2ban on the server to block IPs with too many failures.
This is an additional layer compare to the ban system already existing in BoZoN.

Hope you will find it useful